### PR TITLE
Add OpenTelemetry support

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,34 @@ export default nextConfig;
 ```
 If someone smarter than me knows how to include an optional JS build from a TS library please submit a PR. I just don't want to deploy a compiled version of this and wind up having folks doubling up on an already gargantuan dependency.
 
+## Telemetry
+
+Passkey kit can emit OpenTelemetry traces. Telemetry is disabled by default and can
+be configured in code or via environment variables.
+
+```ts
+import { TelemetryService } from "passkey-kit/telemetry"
+
+TelemetryService.init({
+  enabled: true,
+  serviceName: "my-passkey-service",
+  exporter: {
+    type: "otlp",
+    endpoint: "http://localhost:4318",
+    headers: { Authorization: "Bearer my-token" }
+  }
+})
+```
+
+Environment variables:
+
+```bash
+TELEMETRY_ENABLED=true
+TELEMETRY_SERVICE_NAME=passkey-kit
+TELEMETRY_EXPORTER_TYPE=otlp
+TELEMETRY_OTLP_ENDPOINT=http://localhost:4318
+```
+
 ## Contributing 
 
 Passkey kit consists of three primary directories:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,10 @@
     "@stellar/stellar-sdk": "^13.3.0",
     "base64url": "^3.0.1",
     "buffer": "^6.0.3",
+    "@opentelemetry/api": "^1.7.0",
+    "@opentelemetry/sdk-trace-node": "^1.7.0",
+    "@opentelemetry/exporter-trace-otlp-http": "^1.7.0",
+    "@opentelemetry/exporter-trace-console": "^1.7.0",
     "passkey-kit-sdk": "workspace:*",
     "sac-sdk": "workspace:*"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,9 @@ export { PasskeyKit } from "./kit"
 export { PasskeyServer } from "./server"
 export { SACClient } from "./sac"
 export { Client as PasskeyClient } from 'passkey-kit-sdk'
+export * from './telemetry'
+
+import { TelemetryService } from './telemetry/TelemetryService'
+import { getTelemetryConfigFromEnv } from './telemetry/env'
+
+TelemetryService.init(getTelemetryConfigFromEnv())

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -8,6 +8,7 @@ import type { SignerKey, SignerLimits, SignerStore } from './types'
 import { PasskeyBase } from './base'
 import { AssembledTransaction, basicNodeSigner, type AssembledTransactionOptions, type Tx } from '@stellar/stellar-sdk/minimal/contract'
 import type { Server } from '@stellar/stellar-sdk/minimal/rpc'
+import { TelemetryService } from "./telemetry/TelemetryService"
 
 export class PasskeyKit extends PasskeyBase {
     declare rpc: Server
@@ -54,9 +55,12 @@ export class PasskeyKit extends PasskeyBase {
     }
 
     public async createWallet(app: string, user: string) {
-        const { rawResponse, keyId, keyIdBase64, publicKey } = await this.createKey(app, user)
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('wallet.create')
+        try {
+            const { rawResponse, keyId, keyIdBase64, publicKey } = await this.createKey(app, user)
 
-        const at = await PasskeyClient.deploy(
+            const at = await PasskeyClient.deploy(
             {
                 signer: {
                     tag: 'Secp256r1',
@@ -79,24 +83,31 @@ export class PasskeyKit extends PasskeyBase {
             }
         )
 
-        const contractId = at.result.options.contractId
+            const contractId = at.result.options.contractId
 
-        this.wallet = new PasskeyClient({
-            contractId,
-            networkPassphrase: this.networkPassphrase,
-            rpcUrl: this.rpcUrl
-        })
+            this.wallet = new PasskeyClient({
+                contractId,
+                networkPassphrase: this.networkPassphrase,
+                rpcUrl: this.rpcUrl
+            })
 
-        await at.sign({
-            signTransaction: basicNodeSigner(this.walletKeypair, this.networkPassphrase).signTransaction
-        })
+            await at.sign({
+                signTransaction: basicNodeSigner(this.walletKeypair, this.networkPassphrase).signTransaction
+            })
 
-        return {
-            rawResponse,
-            keyId,
-            keyIdBase64,
-            contractId,
-            signedTx: at.signed!
+            span.setStatus({ code: 1 })
+            return {
+                rawResponse,
+                keyId,
+                keyIdBase64,
+                contractId,
+                signedTx: at.signed!
+            }
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
         }
     }
 
@@ -104,7 +115,10 @@ export class PasskeyKit extends PasskeyBase {
         rpId?: string
         authenticatorSelection?: AuthenticatorSelectionCriteria
     }) {
-        const now = new Date()
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('wallet.createKey')
+        try {
+            const now = new Date()
         const displayName = `${user} — ${now.toLocaleString()}`
         const { rpId, authenticatorSelection = {
             residentKey: "preferred",
@@ -116,7 +130,7 @@ export class PasskeyKit extends PasskeyBase {
         // In this case we should save the passkey info and retry uploading it async vs asking the user to create another passkey
         // This does introduce a storage dependency though so it likely needs to be a function with some logic for choosing how to store the passkey data
 
-        const rawResponse = await this.WebAuthn.startRegistration({
+            const rawResponse = await this.WebAuthn.startRegistration({
             optionsJSON: {
                 challenge: base64url("stellaristhebetterblockchain"),
                 rp: {
@@ -132,16 +146,23 @@ export class PasskeyKit extends PasskeyBase {
                 pubKeyCredParams: [{ alg: -7, type: "public-key" }],
             }
         });
-        const { id, response } = rawResponse
+            const { id, response } = rawResponse
 
-        if (!this.keyId)
-            this.keyId = id;
+            if (!this.keyId)
+                this.keyId = id;
 
-        return {
-            rawResponse,
-            keyId: base64url.toBuffer(id),
-            keyIdBase64: id,
-            publicKey: await this.getPublicKey(response),
+            span.setStatus({ code: 1 })
+            return {
+                rawResponse,
+                keyId: base64url.toBuffer(id),
+                keyIdBase64: id,
+                publicKey: await this.getPublicKey(response),
+            }
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
         }
     }
 
@@ -153,9 +174,13 @@ export class PasskeyKit extends PasskeyBase {
         // Consider putting this somewhere else??
         walletPublicKey?: string
     }) {
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('wallet.connect')
         let { rpId, keyId, getContractId, walletPublicKey } = opts || {}
         let keyIdBuffer: Buffer
         let rawResponse: AuthenticationResponseJSON | undefined;
+
+        try {
 
         if (!keyId) {
             rawResponse = await this.WebAuthn.startAuthentication({
@@ -206,20 +231,27 @@ export class PasskeyKit extends PasskeyBase {
         }
         ////
 
-        if (!contractId)
-            throw new Error('Failed to connect wallet')
+            if (!contractId)
+                throw new Error('Failed to connect wallet')
 
-        this.wallet = new PasskeyClient({
-            contractId,
-            rpcUrl: this.rpcUrl,
-            networkPassphrase: this.networkPassphrase,
-        })
+            this.wallet = new PasskeyClient({
+                contractId,
+                rpcUrl: this.rpcUrl,
+                networkPassphrase: this.networkPassphrase,
+            })
 
-        return {
-            rawResponse,
-            keyId: keyIdBuffer,
-            keyIdBase64: keyId,
-            contractId
+            span.setStatus({ code: 1 })
+            return {
+                rawResponse,
+                keyId: keyIdBuffer,
+                keyIdBase64: keyId,
+                contractId
+            }
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
         }
     }
 
@@ -233,7 +265,11 @@ export class PasskeyKit extends PasskeyBase {
             expiration?: number
         }
     ) {
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('wallet.signAuthEntry')
         let { rpId, keyId, keypair, policy, expiration } = options || {}
+
+        try {
 
         if ([keyId, keypair, policy].filter((arg) => !!arg).length > 1)
             throw new Error('Exactly one of `options.keyId`, `options.keypair`, or `options.policy` must be provided.');
@@ -410,7 +446,14 @@ export class PasskeyKit extends PasskeyBase {
         //     )
         // })
 
-        return entry
+            span.setStatus({ code: 1 })
+            return entry
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
+        }
     }
 
     public async sign<T>(
@@ -423,7 +466,10 @@ export class PasskeyKit extends PasskeyBase {
             expiration?: number
         }
     ) {
-        if (!(txn instanceof AssembledTransaction)) {
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('wallet.sign')
+        try {
+            if (!(txn instanceof AssembledTransaction)) {
             try {
                 txn = AssembledTransaction.fromXDR(this.wallet!.options, typeof txn === 'string' ? txn : txn.toXDR(), this.wallet!.spec)
             } catch {
@@ -439,15 +485,21 @@ export class PasskeyKit extends PasskeyBase {
             }
         }
 
-        await txn.signAuthEntries({
+            await txn.signAuthEntries({
             address: this.wallet!.options.contractId,
             authorizeEntry: (entry) => {
                 const clone = xdr.SorobanAuthorizationEntry.fromXDR(entry.toXDR())
                 return this.signAuthEntry(clone, options)
             },
         })
-
-        return txn
+            span.setStatus({ code: 1 })
+            return txn
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
+        }
     }
 
     public addSecp256r1(keyId: string | Uint8Array, publicKey: string | Uint8Array, limits: SignerLimits, store: SignerStore, expiration?: number) {

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,7 @@ import type { Signer } from "./types"
 import { AssembledTransaction } from "@stellar/stellar-sdk/minimal/contract"
 import { Durability } from "@stellar/stellar-sdk/minimal/rpc"
 import { version } from '../package.json'
+import { TelemetryService } from "./telemetry/TelemetryService"
 
 // TODO set default headers in constructor
 
@@ -65,10 +66,13 @@ export class PasskeyServer extends PasskeyBase {
     }
 
     public async getSigners(contractId: string) {
-        if (!this.rpc || !this.mercuryProjectName || !this.mercuryUrl || (!this.mercuryJwt && !this.mercuryKey))
-            throw new Error('Mercury service not configured')
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('server.getSigners')
+        try {
+            if (!this.rpc || !this.mercuryProjectName || !this.mercuryUrl || (!this.mercuryJwt && !this.mercuryKey))
+                throw new Error('Mercury service not configured')
 
-        const signers = await fetch(`${this.mercuryUrl}/zephyr/execute`, {
+            const signers = await fetch(`${this.mercuryUrl}/zephyr/execute`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -93,7 +97,7 @@ export class PasskeyServer extends PasskeyBase {
                 throw await res.json()
             })
 
-        for (const signer of signers) {
+            for (const signer of signers) {
             if (signer.storage === 'Temporary') {
                 try {
                     await this.rpc.getContractData(contractId, xdr.ScVal.scvBytes(base64url.toBuffer(signer.key)), Durability.Temporary)
@@ -101,9 +105,16 @@ export class PasskeyServer extends PasskeyBase {
                     signer.evicted = true
                 }
             }
-        }
+            }
 
-        return signers as Signer[]
+            span.setStatus({ code: 1 })
+            return signers as Signer[]
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
+        }
     }
 
     public async getContractId(options: {
@@ -111,10 +122,13 @@ export class PasskeyServer extends PasskeyBase {
         publicKey?: string,
         policy?: string,
     }, index = 0) {
-        if (!this.mercuryProjectName || !this.mercuryUrl || (!this.mercuryJwt && !this.mercuryKey))
-            throw new Error('Mercury service not configured')
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('server.getContractId')
+        try {
+            if (!this.mercuryProjectName || !this.mercuryUrl || (!this.mercuryJwt && !this.mercuryKey))
+                throw new Error('Mercury service not configured')
 
-        let { keyId, publicKey, policy } = options || {}
+            let { keyId, publicKey, policy } = options || {}
 
         if ([keyId, publicKey, policy].filter((arg) => !!arg).length > 1)
             throw new Error('Exactly one of `options.keyId`, `options.publicKey`, or `options.policy` must be provided.');
@@ -128,7 +142,7 @@ export class PasskeyServer extends PasskeyBase {
         else if (policy)
             args = { key: policy, kind: 'Policy' }
 
-        const res = await fetch(`${this.mercuryUrl}/zephyr/execute`, {
+            const res = await fetch(`${this.mercuryUrl}/zephyr/execute`, {
             method: 'POST',
             headers: {
                 'Content-Type': 'application/json',
@@ -151,7 +165,14 @@ export class PasskeyServer extends PasskeyBase {
                 throw await res.json()
             })
 
-        return res[index]
+            span.setStatus({ code: 1 })
+            return res[index]
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.end()
+        }
     }
 
     /* LATER
@@ -159,13 +180,16 @@ export class PasskeyServer extends PasskeyBase {
     */
 
     public async send<T>(
-        txn: AssembledTransaction<T> | Tx | string, 
+        txn: AssembledTransaction<T> | Tx | string,
         fee?: number,
     ) {
-        if (!this.launchtubeUrl)
-            throw new Error('Launchtube service not configured')
+        const tracer = TelemetryService.getTracer('passkey-kit')
+        const span = tracer.startSpan('server.send')
+        try {
+            if (!this.launchtubeUrl)
+                throw new Error('Launchtube service not configured')
 
-        const data = new FormData();
+            const data = new FormData();
 
         if (txn instanceof AssembledTransaction) {
             txn = txn.built!.toXDR()
@@ -186,7 +210,7 @@ export class PasskeyServer extends PasskeyBase {
         if (this.launchtubeJwt)
             lt_headers.authorization = `Bearer ${this.launchtubeJwt}`
 
-        return fetch(this.launchtubeUrl, {
+            return fetch(this.launchtubeUrl, {
             method: 'POST',
             headers: lt_headers,
             body: data
@@ -194,6 +218,13 @@ export class PasskeyServer extends PasskeyBase {
             if (res.ok)
             return res.json()
             else throw await res.json()
-        })
+            })
+        } catch (e) {
+            span.recordException(e)
+            throw e
+        } finally {
+            span.setStatus({ code: 1 })
+            span.end()
+        }
     }
 }

--- a/src/telemetry/TelemetryService.ts
+++ b/src/telemetry/TelemetryService.ts
@@ -1,0 +1,40 @@
+import { NodeTracerProvider } from "@opentelemetry/sdk-trace-node"
+import { trace } from "@opentelemetry/api"
+import { BatchSpanProcessor } from "@opentelemetry/sdk-trace-base"
+import { OTLPTraceExporter } from "@opentelemetry/exporter-trace-otlp-http"
+import type { TelemetryConfig } from "./types"
+
+let isInitialized = false
+
+export class TelemetryService {
+    static init(config: TelemetryConfig) {
+        if (!config.enabled || isInitialized)
+            return
+
+        const provider = new NodeTracerProvider()
+        const { type, endpoint, headers, exporterInstance } = config.exporter
+
+        let exporter: any
+
+        if (type === "otlp") {
+            exporter = new OTLPTraceExporter({ url: endpoint, headers })
+        } else if (type === "console") {
+            const { ConsoleSpanExporter } = require("@opentelemetry/exporter-trace-console")
+            exporter = new ConsoleSpanExporter()
+        } else if (type === "custom" && exporterInstance) {
+            exporter = exporterInstance
+        } else {
+            console.warn("Telemetry exporter misconfigured")
+            return
+        }
+
+        provider.addSpanProcessor(new BatchSpanProcessor(exporter))
+        provider.register()
+
+        isInitialized = true
+    }
+
+    static getTracer(serviceName: string) {
+        return trace.getTracer(serviceName)
+    }
+}

--- a/src/telemetry/env.ts
+++ b/src/telemetry/env.ts
@@ -1,0 +1,16 @@
+import type { TelemetryConfig, ExporterType } from "./types"
+
+export function getTelemetryConfigFromEnv(): TelemetryConfig {
+    return {
+        enabled: process.env.TELEMETRY_ENABLED === "true",
+        serviceName: process.env.TELEMETRY_SERVICE_NAME || "passkey-kit",
+        samplingRate: parseFloat(process.env.TELEMETRY_SAMPLING || "1.0"),
+        exporter: {
+            type: process.env.TELEMETRY_EXPORTER_TYPE as ExporterType || "console",
+            endpoint: process.env.TELEMETRY_OTLP_ENDPOINT,
+            headers: process.env.TELEMETRY_OTLP_HEADERS
+                ? JSON.parse(process.env.TELEMETRY_OTLP_HEADERS)
+                : undefined,
+        }
+    }
+}

--- a/src/telemetry/index.ts
+++ b/src/telemetry/index.ts
@@ -1,0 +1,3 @@
+export { TelemetryService } from './TelemetryService'
+export { getTelemetryConfigFromEnv } from './env'
+export type { TelemetryConfig, ExporterType } from './types'

--- a/src/telemetry/types.ts
+++ b/src/telemetry/types.ts
@@ -1,0 +1,13 @@
+export type ExporterType = "otlp" | "console" | "custom"
+
+export interface TelemetryConfig {
+  enabled: boolean
+  serviceName: string
+  samplingRate?: number
+  exporter: {
+    type: ExporterType
+    endpoint?: string
+    headers?: Record<string, string>
+    exporterInstance?: any
+  }
+}


### PR DESCRIPTION
## Summary
- implement optional TelemetryService and config env helpers
- instrument wallet and server methods with spans
- initialize telemetry from environment
- document telemetry usage in README
- add OpenTelemetry packages to dependencies

## Testing
- `pnpm install` *(fails: Error when performing the request to https://registry.npmjs.org/...)*
- `pnpm run build` *(fails: Error when performing the request to https://registry.npmjs.org/...)*

------
https://chatgpt.com/codex/tasks/task_e_688537625bbc832caf815529c83f0701