### PR TITLE
Add configurable logging

### DIFF
--- a/PINO_PRD.md
+++ b/PINO_PRD.md
@@ -1,0 +1,160 @@
+PRD: Flexible Logging Integration for passkey-kit
+Feature: Pino-Based Structured Logging with Custom Transports
+Repository: https://github.com/freelii/passkey-kit
+Objective: Introduce a pluggable logging system using Pino, modeled after Mastra’s architecture. The logger should support structured logs, custom transports (e.g., Datadog, HTTP, console), and be fully configurable via the constructor of PasskeyKit and PasskeyServer, rather than relying on environment variables.
+
+🧩 Goals
+Use Pino for structured logging.
+
+Allow users to configure the logger directly via the PasskeyKit and PasskeyServer constructors.
+
+Support multiple simultaneous log transports (console, HTTP, Datadog, etc.).
+
+Enable integration of custom Transform streams via a utility.
+
+Log important lifecycle events such as wallet creation, transaction signing, XDR generation, etc.
+
+Match the extensibility of Mastra’s PinoLogger.
+
+✅ Acceptance Criteria
+ Logger supports structured JSON logs.
+
+ Developers can pass a logger or loggingConfig into the constructors of PasskeyKit and PasskeyServer.
+
+ Logging supports:
+
+ Pretty console output
+
+ Optional custom transports (Datadog, HTTP, etc.)
+
+ LoggingService is a singleton or globally accessible utility once initialized.
+
+ Instrument at least the following methods:
+
+createWallet
+
+createKey
+
+connect
+
+signAuthEntry
+
+sign
+
+ Clear README and TS types for configuration.
+
+🏗️ Technical Plan
+1. Constructor Interface Changes
+Update constructors for PasskeyKit and PasskeyServer to accept:
+
+ts
+Copiar
+Editar
+interface PasskeyOptions {
+  ...
+  logging?: LoggingConfig | pino.Logger;
+}
+And in each constructor:
+
+ts
+Copiar
+Editar
+import { LoggingService } from './logging/LoggingService';
+
+constructor(opts: PasskeyOptions) {
+  ...
+  if (opts.logging) LoggingService.init(opts.logging);
+}
+2. LoggingService.ts
+Same implementation as before, but initialization comes from constructor-provided config only (no .env parsing):
+
+ts
+Copiar
+Editar
+static init(config: LoggingConfig | pino.Logger) {
+  if (isPinoLogger(config)) {
+    logger = config;
+    return;
+  }
+
+  const streams: pino.StreamEntry[] = [];
+
+  const prettyStream = pretty({ colorize: true });
+  streams.push({ stream: prettyStream, level: config.level || 'info' });
+
+  Object.entries(config.transports || {}).forEach(([, stream]) => {
+    streams.push({ stream, level: config.level || 'info' });
+  });
+
+  logger = pino({ name: config.name || 'passkey-kit', level: config.level || 'info' }, pino.multistream(streams));
+}
+3. Usage Example
+ts
+Copiar
+Editar
+import { PasskeyKit } from 'passkey-kit';
+import { createCustomTransport } from 'passkey-kit/logging';
+import pinoDatadog from 'pino-datadog-transport';
+
+const ddStream = pinoDatadog({ /* your datadog config */ });
+const ddTransport = createCustomTransport(ddStream);
+
+const kit = new PasskeyKit({
+  rpcUrl: 'https://soroban-rpc.testnet.stellar.org',
+  logging: {
+    level: 'info',
+    transports: { datadog: ddTransport },
+  },
+});
+4. Remove env.ts
+No .env parsing is needed. Delete src/logging/env.ts.
+
+5. Logger Types (types.ts)
+ts
+Copiar
+Editar
+export interface LoggingConfig {
+  name?: string;
+  level?: 'info' | 'debug' | 'error' | 'warn';
+  transports?: Record<string, Transform>;
+}
+
+export interface LoggerTransport extends Transform {}
+6. Instrumented Logging in Core Methods
+Replace or complement existing TelemetryService usage with:
+
+ts
+Copiar
+Editar
+const logger = LoggingService.get();
+logger.info("wallet.createWallet", { user, app, walletId });
+logger.error("wallet.sign.error", { error, xdr });
+7. README Usage Example
+ts
+Copiar
+Editar
+import { PasskeyKit } from "passkey-kit";
+import { createCustomTransport } from "passkey-kit/logging";
+import pinoDatadog from "pino-datadog-transport";
+
+const datadogStream = pinoDatadog({ ... });
+const loggerTransport = createCustomTransport(datadogStream);
+
+const kit = new PasskeyKit({
+  logging: {
+    level: 'info',
+    transports: {
+      datadog: loggerTransport
+    }
+  }
+});
+🧪 Test Cases
+ ✅ Logs show in console by default if pretty transport used.
+
+ ✅ PasskeyKit accepts logging option and forwards logs.
+
+ ✅ Structured logs include metadata (e.g. walletId, xdr).
+
+ ✅ Multiple transports work concurrently.
+
+ ✅ Datadog transport logs are sent using a custom stream.

--- a/PINO_REFERENCE_DOC.md
+++ b/PINO_REFERENCE_DOC.md
@@ -1,0 +1,208 @@
+Integrating Custom Logging (à la Mastra) into Passkey Kit
+Mastra’s Flexible Pino Logging Architecture
+Mastra implements a robust logging system built on Pino, enabling logs to be routed to various destinations (console, files, external services) via a transport-based architecture. The core is the PinoLogger class, which extends an abstract MastraLogger base. This design allows injecting custom transports (outputs) when configuring the logger
+mastra.ai
+mastra.ai
+. In practice, a Mastra logger instance is created like:
+const logger = new PinoLogger({ 
+  name: "Mastra", 
+  level: "info",
+  transports: { /* custom transports can be added here */ }
+});
+The logger provides standard methods (debug, info, warn, error) to record events at various severity levels
+mastra.ai
+mastra.ai
+. Depending on its configuration, log messages can be written to the console, a file, or sent to an external monitoring service
+mastra.ai
+. By default, if no custom transport is added, Mastra uses a pretty-print console stream for human-readable logs. If transports are provided, Mastra leverages Pino’s multi-stream capability to broadcast each log record to all configured destinations simultaneously
+mastra.ai
+mastra.ai
+. This means you can have, for example, console output for local debugging and a remote log service (like Datadog) receiving the same log events in JSON form. Under the hood, transports in Mastra are implemented as Node.js Transform streams. Mastra defines a LoggerTransport class (subclassing Transform) to represent a log destination stream with optional methods for retrieving logs (used for querying saved logs)
+mastra.ai
+. Each transport stream consumes Pino log objects and sends them onward – e.g. writing to a file, making an HTTP request, etc. The use of Transform streams makes the system very flexible: you can pipe log data to any target by providing a stream that implements a _transform method
+mastra.ai
+. For example, Mastra’s deployment module creates a custom Transform to capture child process output and feed it into the logger, illustrating that even process streams can be integrated as log input.
+Custom Transports for External Services
+A key feature of Mastra’s logger is the ability to plug in custom transports for external monitoring services (Datadog, Sentry, etc.). Mastra provides a utility function createCustomTransport(stream) which takes a Transform stream and wraps it as a LoggerTransport instance
+mastra.ai
+. This allows developers to define an arbitrary stream (for example, one that sends log data to an HTTP API or third-party SDK) and then attach it to the PinoLogger. The logger will treat it as just another output destination. How it works: Suppose you have a stream that sends data to an external service. You create that stream (often using a third-party library or custom code), then call createCustomTransport(yourStream). The returned object can be added to the logger’s transports. From then on, every log message (as a JSON object) is passed into your stream’s _transform function for processing. Example – Sentry Integration: In Mastra’s documentation, there’s a clear example of adding a Sentry.io transport using this method. They use a community Pino transport pino-sentry-transport to get a Sentry-bound stream, then wrap it for Mastra:
+import { createCustomTransport } from "@mastra/core/loggers";
+import pinoSentry from "pino-sentry-transport";
+
+const sentryStream = await pinoSentry({
+  sentry: { dsn: "YOUR_SENTRY_DSN", _experiments: { enableLogs: true } }
+});
+const sentryTransport = createCustomTransport(sentryStream);
+
+const logger = new PinoLogger({
+  name: "Mastra",
+  transports: { sentry: sentryTransport },
+  level: "info",
+});
+[The above Sentry integration is adapted from Mastra’s docs
+mastra.ai
+mastra.ai
+ – it shows the pattern for wrapping any custom log stream.] This transport-based approach means Datadog integration is absolutely feasible in the same manner. The Mastra logger doesn’t have special-case code for Datadog; instead it provides the generic plumbing to hook in any service. For Datadog, one could use Datadog’s own logging client or a Pino transport library. For instance, the community package pino-datadog-transport can batch and send logs to Datadog’s HTTP API
+github.com
+. Using it with Mastra’s system would be straightforward: create the Datadog stream and wrap it. Conceptually:
+import pinoDatadog from "pino-datadog-transport";
+// ... configure pinoDatadog with your Datadog API key, site, etc.
+const ddStream = pinoDatadog({ 
+  ddClientConf: { authMethods: { apiKeyAuth: "<DATADOG_API_KEY>" } },
+  ddServerConf: { site: "datadoghq.com" }  // or EU site, etc:contentReference[oaicite:15]{index=15}
+});
+const ddTransport = createCustomTransport(ddStream);
+
+const logger = new PinoLogger({
+  name: "MyService",
+  level: "info",
+  transports: { datadog: ddTransport }
+});
+With this setup, every call like logger.info("XDR signed", { transactionId, ... }) would emit a log object to both the console (pretty printed) and to Datadog via the custom transport. Mastra’s use of pino.multistream under the hood ensures multiple transports can receive the logs concurrently
+mastra.ai
+mastra.ai
+.
+Applying a Similar Logging System to Passkey Kit
+Currently, the Passkey Kit SDK has minimal built-in logging. To enhance observability (especially for events like Stellar transaction creation, signing, XDR outputs, etc.), we can introduce a Mastra-inspired logging architecture:
+Adopt Pino for Structured Logging: Incorporate Pino as the logging library in Passkey Kit. Pino is chosen for its performance and ability to emit structured JSON logs which are easily parsed by monitoring tools. We might create a PasskeyLogger (akin to Mastra’s PinoLogger) that wraps a Pino instance.
+Transport Configuration at Build/Init Time: Allow developers to configure logging outputs when they initialize the library (or via environment variables at build time). For example, Passkey Kit could expose a configuration where you can enable an external log transport. This is similar to how Passkey Kit’s telemetry (TelemetryService) can be toggled via code or env variables. We can introduce something like LoggingService.init({ transports: ..., level: ... }) or options in the PasskeyKit constructor for logging. Environment variables (e.g., LOG_DATADOG_ENABLED, DATADOG_API_KEY, etc.) could be read to decide if the Datadog transport should be attached, making it configurable without code changes at build/deploy time.
+Custom Transports for Monitoring Services: Emulate Mastra’s createCustomTransport pattern. We can provide a utility to wrap any Node.js Stream as a Passkey Kit log transport. In practice, we’d likely integrate a Datadog stream. For instance, using Datadog’s official Node client or a Pino Datadog transport, we create a Transform stream that sends logs to Datadog. Then, wrap it so that our logger can use it. The result would enable sending Passkey Kit logs to Datadog (or any similar service) seamlessly. This design means you aren’t limited to Datadog – you could plug in Sentry, Logstash, or any custom endpoint by providing the appropriate stream.
+Multiple Simultaneous Outputs: Like Mastra, Passkey Kit’s logger can default to console output (for developer visibility) while also forwarding logs to external services. Using Pino’s multi-stream support, we ensure that adding a Datadog transport doesn’t remove the existing console log; instead, both will receive the events. This is crucial for debugging locally while still capturing logs centrally in production. The configuration might allow overriding default transports if needed (Mastra has an overrideDefaultTransports option), but by default we’d merge custom transports with console logging.
+Structured Log Content: As we add logging calls in Passkey Kit’s code (for example, when a wallet is created, a transaction XDR is generated, a transaction is signed, etc.), we should log structured data. Pino allows logging objects, not just strings. For example, when PasskeyKit.createWallet() is called, we could log an info-level entry like: { message: "Wallet created", user, app, walletId: ..., publicKey: ... }. This way, DataDog or other services can index fields like walletId or user. Mastra’s logger encourages structured logs with fields like destinationPath or type for categorization
+mastra.ai
+mastra.ai
+. We might define similar conventions for Passkey Kit (e.g., a field indicating the operation type such as "passkey.operation": "createWallet").
+Leveraging OpenTelemetry (if applicable): It’s worth noting that Passkey Kit recently introduced OpenTelemetry tracing (as seen in the diff adding TelemetryService.init and spans around wallet.create). Logging can complement tracing by recording high-level events and payloads. The logging system we add could optionally include trace IDs (if available) in log entries, so that logs and traces correlate in systems like Datadog (which can ingest both APM traces and logs). This would require capturing the current trace/span context in the log metadata, which Pino supports via hooks or by passing context explicitly.
+Example: DataDog Logging Integration in Passkey Kit
+To illustrate how Datadog integration might look, imagine enabling it via environment and code: Environment config:
+LOG_DATADOG=true  
+DATADOG_API_KEY=<your API key>  
+DATADOG_SITE=datadoghq.com  
+LOG_LEVEL=info  
+Code usage in Passkey Kit:
+On initialization, Passkey Kit’s logging service checks LOG_DATADOG. If true, it uses a Datadog transport. Using a Pino transport library for Datadog, the code could resemble:
+import { createCustomTransport } from "passkey-kit/logging";
+import pinoDatadog from "pino-datadog-transport";
+
+const transports: Record<string, any> = {};
+if (process.env.LOG_DATADOG) {
+  const ddStream = pinoDatadog({
+    ddClientConf: { authMethods: { apiKeyAuth: process.env.DATADOG_API_KEY } },
+    ddServerConf: { site: process.env.DATADOG_SITE || "datadoghq.com" }
+  });
+  transports.datadog = createCustomTransport(ddStream);
+}
+
+const logger = new PasskeyLogger({ level: process.env.LOG_LEVEL || "info", transports });
+logger.info("PasskeyKit initialized", { service: "passkey-kit", version: "X.Y.Z" });
+Every meaningful operation within Passkey Kit would use logger.debug/info/error calls. For example, when a transaction is signed:
+logger.info("Transaction signed", { 
+  txId: signedTx.hash, 
+  xdr: signedTx.toXDR(), 
+  operation: "wallet.sign" 
+});
+If Datadog logging is enabled, that info will be sent to Datadog with all the structured data (and still printed to console for local dev). Datadog’s logs UI would then allow filtering by fields like operation: wallet.sign or seeing the txId and XDR for troubleshooting. This aligns with Mastra’s approach of capturing both human-readable and machine-parseable logs.
+Summary of Benefits
+By mirroring Mastra’s logging architecture in Passkey Kit, we gain:
+Pluggability: Developers can integrate any logging/monitoring provider (Datadog, Splunk, Sentry, etc.) by adding a custom transport, without modifying Passkey Kit’s core logic. Mastra’s createCustomTransport concept makes this extensible
+mastra.ai
+.
+Configurability: Logging destinations and levels can be configured at build or startup time. For instance, one could enable verbose logging in a staging environment with console output, but in production pipe the logs to Datadog for long-term retention and analysis.
+Minimal Overhead & Structured Data: Pino’s design ensures high performance. Logging in JSON means that context (like user IDs, wallet IDs, error details) can be included in each log entry. This is crucial for monitoring complex processes like multi-step Stellar transactions. Mastra’s own use of structured fields (e.g., runId for correlation
+mastra.ai
+) demonstrates how logs can be tied to specific operations or workflows – Passkey Kit can use similar techniques (like attaching a passkey ID or transaction hash to each log).
+Multiple Outputs for Developer Convenience: The multi-stream logging means developers don’t lose the simplicity of console.log during development. They can see logs in the terminal and have them forwarded to a service in parallel. This dual-output approach was effectively used in Mastra (e.g., sending logs to a file or HTTP endpoint while still pretty-printing to stdout
+mastra.ai
+mastra.ai
+).
+In conclusion, Mastra’s logging system provides an excellent blueprint for enhancing Passkey Kit’s observability. By introducing a Pino-based logger with configurable transports, we can enable first-class support for Datadog and other log aggregators. The implementation would involve creating a logging module in Passkey Kit that mirrors Mastra’s transport mechanism, allowing for flexible integration at build time and ensuring that critical events (like XDR creation, signature operations, etc.) are captured for monitoring and debugging purposes. This will make it much easier to operate Passkey-based applications in production, with rich logs flowing into your monitoring dashboards. Sources:
+Mastra Observability Docs – Logger Instance and Custom Transports
+mastra.ai
+mastra.ai
+Mastra Code Examples – File and Upstash transports, multi-stream configuration
+mastra.ai
+mastra.ai
+Pino Datadog Transport – GitHub README (usage and config)
+github.com
+github.com
+Citas
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+GitHub - theogravity/pino-datadog-transport: A pino v7+ transport for sending logs to Datadog
+
+https://github.com/theogravity/pino-datadog-transport
+
+GitHub - theogravity/pino-datadog-transport: A pino v7+ transport for sending logs to Datadog
+
+https://github.com/theogravity/pino-datadog-transport
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+
+Reference: Logger Instance | Mastra Observability Docs
+
+https://mastra.ai/en/reference/observability/logger
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+1.diff.txt
+
+file://file-V2dtzuXNpqHuYRAjUUcmte
+
+GitHub - theogravity/pino-datadog-transport: A pino v7+ transport for sending logs to Datadog
+
+https://github.com/theogravity/pino-datadog-transport

--- a/README.md
+++ b/README.md
@@ -38,23 +38,94 @@ Good luck, have fun, and change the world!
 
 ## Logging
 
+The Passkey Kit supports structured logging using Pino with customizable transports for sending logs to various destinations (console, files, monitoring services like Datadog, etc.).
+
+### Basic Usage
+
+```ts
+import { PasskeyKit } from "passkey-kit";
+
+// Basic console logging (default behavior)
+const kit = new PasskeyKit({
+  rpcUrl: 'https://soroban-rpc.testnet.stellar.org',
+  logging: {
+    level: 'info'  // 'debug' | 'info' | 'warn' | 'error'
+  }
+});
+```
+
+### Custom Transport Integration
+
+Add external monitoring services using custom transports:
+
 ```ts
 import { PasskeyKit } from "passkey-kit";
 import { createCustomTransport } from "passkey-kit/logging";
 import pinoDatadog from "pino-datadog-transport";
 
-const datadogStream = pinoDatadog({ /* your datadog config */ });
-const loggerTransport = createCustomTransport(datadogStream);
+// Configure Datadog transport
+const datadogStream = pinoDatadog({
+  ddClientConf: { 
+    authMethods: { apiKeyAuth: process.env.DATADOG_API_KEY } 
+  },
+  ddServerConf: { 
+    site: "datadoghq.com" 
+  }
+});
+
+const datadogTransport = createCustomTransport(datadogStream);
 
 const kit = new PasskeyKit({
+  rpcUrl: 'https://soroban-rpc.testnet.stellar.org',
   logging: {
     level: 'info',
+    name: 'my-passkey-app',
     transports: {
-      datadog: loggerTransport
+      datadog: datadogTransport
     }
   }
 });
 ```
+
+### Using Your Own Pino Logger
+
+```ts
+import { PasskeyKit } from "passkey-kit";
+import pino from "pino";
+
+const logger = pino({
+  level: 'debug',
+  transport: {
+    target: 'pino-pretty',
+    options: { colorize: true }
+  }
+});
+
+const kit = new PasskeyKit({
+  rpcUrl: 'https://soroban-rpc.testnet.stellar.org',
+  logging: logger  // Pass your own pino instance
+});
+```
+
+### Logged Events
+
+The following operations are automatically logged with structured data:
+
+- **Wallet Creation**: `wallet.create_wallet.start` / `wallet.create_wallet.success`
+- **Key Creation**: `wallet.create_key.start` / `wallet.create_key.success`  
+- **Wallet Connection**: `wallet.connect.start` / `wallet.connect.success`
+- **Transaction Signing**: `wallet.sign.start` / `wallet.sign.success`
+- **Auth Entry Signing**: `wallet.sign_auth_entry.start` / `wallet.sign_auth_entry.success`
+- **Server Operations**: `server.send.success`
+
+Each log entry includes relevant contextual data (user, app, contractId, XDR, etc.) for debugging and monitoring.
+
+### Log Levels
+
+- `debug`: Detailed diagnostic information, including fallback operations and error details
+- `info`: General operational events (wallet creation, signing, etc.)
+- `warn`: Important but non-critical issues  
+- `error`: Error conditions that prevent operations from completing
 
 For any questions or to showcase your progress please join the `#passkeys` channel on our [Discord](https://discord.gg/stellardev).
 

--- a/README.md
+++ b/README.md
@@ -36,6 +36,26 @@ This is a fully typed library so docs aren't provided, however there's a full ex
 
 Good luck, have fun, and change the world!
 
+## Logging
+
+```ts
+import { PasskeyKit } from "passkey-kit";
+import { createCustomTransport } from "passkey-kit/logging";
+import pinoDatadog from "pino-datadog-transport";
+
+const datadogStream = pinoDatadog({ /* your datadog config */ });
+const loggerTransport = createCustomTransport(datadogStream);
+
+const kit = new PasskeyKit({
+  logging: {
+    level: 'info',
+    transports: {
+      datadog: loggerTransport
+    }
+  }
+});
+```
+
 For any questions or to showcase your progress please join the `#passkeys` channel on our [Discord](https://discord.gg/stellardev).
 
 ## Deploy the event indexer

--- a/package.json
+++ b/package.json
@@ -22,6 +22,8 @@
     "@stellar/stellar-sdk": "^13.3.0",
     "base64url": "^3.0.1",
     "buffer": "^6.0.3",
+    "pino": "^8.19.0",
+    "pino-pretty": "^10.3.0",
     "passkey-kit-sdk": "workspace:*",
     "sac-sdk": "workspace:*"
   },

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,3 +3,4 @@ export { PasskeyKit } from "./kit"
 export { PasskeyServer } from "./server"
 export { SACClient } from "./sac"
 export { Client as PasskeyClient } from 'passkey-kit-sdk'
+export * from "./logging";

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -8,6 +8,9 @@ import type { SignerKey, SignerLimits, SignerStore } from './types'
 import { PasskeyBase } from './base'
 import { AssembledTransaction, basicNodeSigner, type AssembledTransactionOptions, type Tx } from '@stellar/stellar-sdk/minimal/contract'
 import type { Server } from '@stellar/stellar-sdk/minimal/rpc'
+import { LoggingService } from './logging'
+import type { LoggingConfig } from './logging'
+import type pino from 'pino'
 
 export class PasskeyKit extends PasskeyBase {
     declare rpc: Server
@@ -34,11 +37,15 @@ export class PasskeyKit extends PasskeyBase {
         WebAuthn?: {
             startRegistration: typeof startRegistration,
             startAuthentication: typeof startAuthentication
-        }
+        },
+        logging?: LoggingConfig | pino.Logger
     }) {
-        const { rpcUrl, networkPassphrase, walletWasmHash, WebAuthn } = options
+        const { rpcUrl, networkPassphrase, walletWasmHash, WebAuthn, logging } = options
 
         super(rpcUrl)
+
+        if (logging)
+            LoggingService.init(logging)
 
         this.networkPassphrase = networkPassphrase
         // this account exists as the seed source for deploying new wallets
@@ -54,6 +61,8 @@ export class PasskeyKit extends PasskeyBase {
     }
 
     public async createWallet(app: string, user: string) {
+        const logger = LoggingService.get()
+        logger.info('wallet.createWallet.start', { app, user })
         const { rawResponse, keyId, keyIdBase64, publicKey } = await this.createKey(app, user)
 
         const at = await PasskeyClient.deploy(
@@ -91,6 +100,8 @@ export class PasskeyKit extends PasskeyBase {
             signTransaction: basicNodeSigner(this.walletKeypair, this.networkPassphrase).signTransaction
         })
 
+        logger.info('wallet.createWallet', { app, user, contractId })
+
         return {
             rawResponse,
             keyId,
@@ -104,6 +115,8 @@ export class PasskeyKit extends PasskeyBase {
         rpId?: string
         authenticatorSelection?: AuthenticatorSelectionCriteria
     }) {
+        const logger = LoggingService.get()
+        logger.info('wallet.createKey.start', { app, user })
         const now = new Date()
         const displayName = `${user} — ${now.toLocaleString()}`
         const { rpId, authenticatorSelection = {
@@ -137,12 +150,15 @@ export class PasskeyKit extends PasskeyBase {
         if (!this.keyId)
             this.keyId = id;
 
-        return {
+        const result = {
             rawResponse,
             keyId: base64url.toBuffer(id),
             keyIdBase64: id,
             publicKey: await this.getPublicKey(response),
         }
+
+        logger.info('wallet.createKey', { app, user, keyId: id })
+        return result
     }
 
     public async connectWallet(opts?: {
@@ -153,7 +169,9 @@ export class PasskeyKit extends PasskeyBase {
         // Consider putting this somewhere else??
         walletPublicKey?: string
     }) {
+        const logger = LoggingService.get()
         let { rpId, keyId, getContractId, walletPublicKey } = opts || {}
+        logger.info('wallet.connect.start', { keyId })
         let keyIdBuffer: Buffer
         let rawResponse: AuthenticationResponseJSON | undefined;
 
@@ -215,12 +233,15 @@ export class PasskeyKit extends PasskeyBase {
             networkPassphrase: this.networkPassphrase,
         })
 
-        return {
+        const result = {
             rawResponse,
             keyId: keyIdBuffer,
             keyIdBase64: keyId,
             contractId
         }
+
+        logger.info('wallet.connect', { contractId, keyId })
+        return result
     }
 
     public async signAuthEntry(
@@ -233,7 +254,9 @@ export class PasskeyKit extends PasskeyBase {
             expiration?: number
         }
     ) {
+        const logger = LoggingService.get()
         let { rpId, keyId, keypair, policy, expiration } = options || {}
+        logger.info('wallet.signAuthEntry.start', { keyId, policy })
 
         if ([keyId, keypair, policy].filter((arg) => !!arg).length > 1)
             throw new Error('Exactly one of `options.keyId`, `options.keypair`, or `options.policy` must be provided.');
@@ -410,6 +433,7 @@ export class PasskeyKit extends PasskeyBase {
         //     )
         // })
 
+        logger.info('wallet.signAuthEntry', { keyId, policy })
         return entry
     }
 
@@ -423,6 +447,8 @@ export class PasskeyKit extends PasskeyBase {
             expiration?: number
         }
     ) {
+        const logger = LoggingService.get()
+        logger.info('wallet.sign.start')
         if (!(txn instanceof AssembledTransaction)) {
             try {
                 txn = AssembledTransaction.fromXDR(this.wallet!.options, typeof txn === 'string' ? txn : txn.toXDR(), this.wallet!.spec)
@@ -446,6 +472,9 @@ export class PasskeyKit extends PasskeyBase {
                 return this.signAuthEntry(clone, options)
             },
         })
+
+        const xdr = typeof txn === 'string' ? txn : txn.toXDR()
+        logger.info('wallet.sign', { xdr })
 
         return txn
     }

--- a/src/kit.ts
+++ b/src/kit.ts
@@ -62,7 +62,7 @@ export class PasskeyKit extends PasskeyBase {
 
     public async createWallet(app: string, user: string) {
         const logger = LoggingService.get()
-        logger.info('wallet.createWallet.start', { app, user })
+        logger.info('wallet.create_wallet.start', { app, user })
         const { rawResponse, keyId, keyIdBase64, publicKey } = await this.createKey(app, user)
 
         const at = await PasskeyClient.deploy(
@@ -100,7 +100,7 @@ export class PasskeyKit extends PasskeyBase {
             signTransaction: basicNodeSigner(this.walletKeypair, this.networkPassphrase).signTransaction
         })
 
-        logger.info('wallet.createWallet', { app, user, contractId })
+        logger.info('wallet.create_wallet.success', { app, user, contractId })
 
         return {
             rawResponse,
@@ -116,7 +116,7 @@ export class PasskeyKit extends PasskeyBase {
         authenticatorSelection?: AuthenticatorSelectionCriteria
     }) {
         const logger = LoggingService.get()
-        logger.info('wallet.createKey.start', { app, user })
+        logger.info('wallet.create_key.start', { app, user })
         const now = new Date()
         const displayName = `${user} — ${now.toLocaleString()}`
         const { rpId, authenticatorSelection = {
@@ -157,7 +157,7 @@ export class PasskeyKit extends PasskeyBase {
             publicKey: await this.getPublicKey(response),
         }
 
-        logger.info('wallet.createKey', { app, user, keyId: id })
+        logger.info('wallet.create_key.success', { app, user, keyId: id })
         return result
     }
 
@@ -206,7 +206,8 @@ export class PasskeyKit extends PasskeyBase {
             await this.rpc.getContractData(contractId, xdr.ScVal.scvLedgerKeyContractInstance())
         }
         // if that fails look up from the `getContractId` function
-        catch {
+        catch (error) {
+            logger.debug('wallet.connect.fallback_lookup', { keyId, error: error instanceof Error ? error.message : String(error) })
             contractId = getContractId && await getContractId(keyId)
         }
 
@@ -218,14 +219,17 @@ export class PasskeyKit extends PasskeyBase {
 
             try {
                 await this.rpc.getContractData(contractId, xdr.ScVal.scvLedgerKeyContractInstance())
-            } catch {
+            } catch (error) {
+                logger.debug('wallet.connect.backwards_compat_failed', { contractId, error: error instanceof Error ? error.message : String(error) })
                 contractId = undefined
             }
         }
         ////
 
-        if (!contractId)
+        if (!contractId) {
+            logger.error('wallet.connect.failed', { keyId, message: 'Failed to connect wallet' })
             throw new Error('Failed to connect wallet')
+        }
 
         this.wallet = new PasskeyClient({
             contractId,
@@ -240,7 +244,7 @@ export class PasskeyKit extends PasskeyBase {
             contractId
         }
 
-        logger.info('wallet.connect', { contractId, keyId })
+        logger.info('wallet.connect.success', { contractId, keyId })
         return result
     }
 
@@ -256,7 +260,7 @@ export class PasskeyKit extends PasskeyBase {
     ) {
         const logger = LoggingService.get()
         let { rpId, keyId, keypair, policy, expiration } = options || {}
-        logger.info('wallet.signAuthEntry.start', { keyId, policy })
+        logger.info('wallet.sign_auth_entry.start', { keyId, policy })
 
         if ([keyId, keypair, policy].filter((arg) => !!arg).length > 1)
             throw new Error('Exactly one of `options.keyId`, `options.keypair`, or `options.policy` must be provided.');
@@ -433,7 +437,7 @@ export class PasskeyKit extends PasskeyBase {
         //     )
         // })
 
-        logger.info('wallet.signAuthEntry', { keyId, policy })
+        logger.info('wallet.sign_auth_entry.success', { keyId, policy })
         return entry
     }
 
@@ -452,7 +456,8 @@ export class PasskeyKit extends PasskeyBase {
         if (!(txn instanceof AssembledTransaction)) {
             try {
                 txn = AssembledTransaction.fromXDR(this.wallet!.options, typeof txn === 'string' ? txn : txn.toXDR(), this.wallet!.spec)
-            } catch {
+            } catch (error) {
+                logger.debug('wallet.sign.xdr_conversion_fallback', { error: error instanceof Error ? error.message : String(error) })
                 if (!(txn instanceof AssembledTransaction)) {
                     const built = TransactionBuilder.fromXDR(typeof txn === 'string' ? txn : txn.toXDR(), this.networkPassphrase);
                     const operation = built.operations[0] as Operation.InvokeHostFunction;
@@ -474,7 +479,7 @@ export class PasskeyKit extends PasskeyBase {
         })
 
         const xdr = typeof txn === 'string' ? txn : txn.toXDR()
-        logger.info('wallet.sign', { xdr })
+        logger.info('wallet.sign.success', { xdr })
 
         return txn
     }

--- a/src/logging/LoggingService.ts
+++ b/src/logging/LoggingService.ts
@@ -1,12 +1,18 @@
 import pino from 'pino';
 import pretty from 'pino-pretty';
-import type { LoggingConfig } from './types';
-import type { Transform } from 'stream';
+import type { LoggingConfig, LoggerTransport } from './types';
+import { Transform } from 'stream';
 
 let logger: pino.Logger | undefined;
 
 function isPinoLogger(obj: any): obj is pino.Logger {
-  return obj && typeof obj.info === 'function' && typeof obj.error === 'function';
+  return obj && 
+    typeof obj === 'object' &&
+    typeof obj.info === 'function' && 
+    typeof obj.error === 'function' &&
+    typeof obj.warn === 'function' &&
+    typeof obj.debug === 'function' &&
+    typeof obj.child === 'function';
 }
 
 export class LoggingService {
@@ -36,6 +42,15 @@ export class LoggingService {
   }
 }
 
-export function createCustomTransport(transform: Transform): Transform {
-  return transform;
+export function createCustomTransport(transform: Transform): LoggerTransport {
+  const transport = transform as LoggerTransport;
+  
+  // Add optional retrieveLogs method if not present
+  if (!transport.retrieveLogs) {
+    transport.retrieveLogs = () => {
+      throw new Error('retrieveLogs not implemented for this transport');
+    };
+  }
+  
+  return transport;
 }

--- a/src/logging/LoggingService.ts
+++ b/src/logging/LoggingService.ts
@@ -1,0 +1,41 @@
+import pino from 'pino';
+import pretty from 'pino-pretty';
+import type { LoggingConfig } from './types';
+import type { Transform } from 'stream';
+
+let logger: pino.Logger | undefined;
+
+function isPinoLogger(obj: any): obj is pino.Logger {
+  return obj && typeof obj.info === 'function' && typeof obj.error === 'function';
+}
+
+export class LoggingService {
+  static init(config: LoggingConfig | pino.Logger) {
+    if (isPinoLogger(config)) {
+      logger = config;
+      return;
+    }
+
+    const streams: pino.StreamEntry[] = [];
+    const level = config.level || 'info';
+    const prettyStream: Transform = pretty({ colorize: true });
+    streams.push({ stream: prettyStream, level });
+
+    Object.entries(config.transports || {}).forEach(([, stream]) => {
+      streams.push({ stream, level });
+    });
+
+    logger = pino({ name: config.name || 'passkey-kit', level }, pino.multistream(streams));
+  }
+
+  static get(): pino.Logger {
+    if (!logger) {
+      logger = pino({ name: 'passkey-kit' }, pino.multistream([ { stream: pretty({ colorize: true }) } ]));
+    }
+    return logger;
+  }
+}
+
+export function createCustomTransport(transform: Transform): Transform {
+  return transform;
+}

--- a/src/logging/index.ts
+++ b/src/logging/index.ts
@@ -1,0 +1,3 @@
+export { LoggingService } from './LoggingService';
+export { createCustomTransport } from './LoggingService';
+export type { LoggingConfig, LoggerTransport } from './types';

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -1,8 +1,11 @@
-export type { Transform } from "stream";
+import { Transform } from "stream";
+
 export interface LoggingConfig {
   name?: string;
   level?: 'info' | 'debug' | 'error' | 'warn';
-  transports?: Record<string, Transform>;
+  transports?: Record<string, LoggerTransport>;
 }
 
-export interface LoggerTransport extends Transform {}
+export interface LoggerTransport extends Transform {
+  retrieveLogs?: () => Promise<any[]> | any[];
+}

--- a/src/logging/types.ts
+++ b/src/logging/types.ts
@@ -1,0 +1,8 @@
+export type { Transform } from "stream";
+export interface LoggingConfig {
+  name?: string;
+  level?: 'info' | 'debug' | 'error' | 'warn';
+  transports?: Record<string, Transform>;
+}
+
+export interface LoggerTransport extends Transform {}

--- a/src/server.ts
+++ b/src/server.ts
@@ -105,7 +105,9 @@ export class PasskeyServer extends PasskeyBase {
             if (signer.storage === 'Temporary') {
                 try {
                     await this.rpc.getContractData(contractId, xdr.ScVal.scvBytes(base64url.toBuffer(signer.key)), Durability.Temporary)
-                } catch {
+                } catch (error) {
+                    const logger = LoggingService.get()
+                    logger.debug('server.get_signer.evicted', { contractId, signerKey: signer.key, error: error instanceof Error ? error.message : String(error) })
                     signer.evicted = true
                 }
             }
@@ -195,7 +197,7 @@ export class PasskeyServer extends PasskeyBase {
         if (this.launchtubeJwt)
             lt_headers.authorization = `Bearer ${this.launchtubeJwt}`
 
-        logger.info('server.send', { xdr: txn })
+        logger.info('server.send.success', { xdr: txn })
         return fetch(this.launchtubeUrl, {
             method: 'POST',
             headers: lt_headers,

--- a/src/server.ts
+++ b/src/server.ts
@@ -6,6 +6,9 @@ import type { Signer } from "./types"
 import { AssembledTransaction } from "@stellar/stellar-sdk/minimal/contract"
 import { Durability } from "@stellar/stellar-sdk/minimal/rpc"
 import { version } from '../package.json'
+import { LoggingService } from './logging'
+import type { LoggingConfig } from './logging'
+import type pino from 'pino'
 
 // TODO set default headers in constructor
 
@@ -28,6 +31,7 @@ export class PasskeyServer extends PasskeyBase {
         mercuryUrl?: string,
         mercuryJwt?: string,
         mercuryKey?: string,
+        logging?: LoggingConfig | pino.Logger,
     }) {
         const {
             rpcUrl,
@@ -38,9 +42,13 @@ export class PasskeyServer extends PasskeyBase {
             mercuryUrl,
             mercuryJwt,
             mercuryKey,
+            logging,
         } = options
 
         super(rpcUrl)
+
+        if (logging)
+            LoggingService.init(logging)
 
         if (launchtubeUrl)
             this.launchtubeUrl = launchtubeUrl
@@ -159,9 +167,10 @@ export class PasskeyServer extends PasskeyBase {
     */
 
     public async send<T>(
-        txn: AssembledTransaction<T> | Tx | string, 
+        txn: AssembledTransaction<T> | Tx | string,
         fee?: number,
     ) {
+        const logger = LoggingService.get()
         if (!this.launchtubeUrl)
             throw new Error('Launchtube service not configured')
 
@@ -186,6 +195,7 @@ export class PasskeyServer extends PasskeyBase {
         if (this.launchtubeJwt)
             lt_headers.authorization = `Bearer ${this.launchtubeJwt}`
 
+        logger.info('server.send', { xdr: txn })
         return fetch(this.launchtubeUrl, {
             method: 'POST',
             headers: lt_headers,


### PR DESCRIPTION
## Summary
- implement Pino based `LoggingService`
- expose logging utilities
- allow logging configuration in `PasskeyKit` and `PasskeyServer`
- instrument wallet methods with structured logs
- document usage of logging
- add pino dependencies

## Testing
- `pnpm install` *(fails: ERR_PNPM_FETCH_403)*
- `pnpm run build` *(fails: tsc: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6885664196cc832c94aa15791e890535